### PR TITLE
Add optional initial release tag link to grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Missing (optional) initial release tag link as last entry in links section to the grammar
 
 ## [0.2.3] - 2019-01-30
 ### Fixed
@@ -40,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - Fixed incorrect Ruby file name in binary
 
-## 0.1.0 - 2019-01-23
+## [0.1.0] - 2019-01-23
 ### Added
 - First draft of the Keep A Changelog parser
 - Open source license and contributing information
@@ -53,3 +55,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.2.0]: https://github.com/cyberark/parse-a-changelog/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/cyberark/parse-a-changelog/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/cyberark/parse-a-changelog/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/cyberark/parse-a-changelog/releases/tag/v0.1.0

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -35,7 +35,7 @@ grammar KeepAChangelog
   rule releases_section
     release*
   end
-  
+
   rule release
     "\n" release_header change_section? ("\n" change_section)*
   end
@@ -53,11 +53,15 @@ grammar KeepAChangelog
   end
 
   rule diff_section
-    "\n" unreleased_diff release_diff*
+    "\n" unreleased_diff release_diff*  initial_release?
   end
 
   rule unreleased_diff
     '[Unreleased]: ' release_url "\n"
+  end
+
+  rule initial_release
+    '[' release_version ']: ' 'https://github.com/' (!'/' .)+ '/' (!'/' .)+ '/releases/tag/v' release_version "\n"
   end
 
   rule release_diff

--- a/spec/fixtures/correct_initial_tag.md
+++ b/spec/fixtures/correct_initial_tag.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added a thing.
+
+### Changed
+- Changed a thing.
+
+## [1.0.0] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## [0.1.0] - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+### Fixed
+- Fixed all the bugs from the non-existent previous release.
+
+### Security
+- We are so secure now.
+- The securest.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/conjurinc/evoke/releases/tag/v0.1.0

--- a/spec/fixtures/malformed_diff_version.md
+++ b/spec/fixtures/malformed_diff_version.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/conjurinc/evoke/invalid_version

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -2,9 +2,14 @@ require_relative '../lib/parse_a_changelog.rb'
 
 describe ParseAChangelog do
   subject(:parser) { ParseAChangelog }
-  
+
   it "parses a correctly-formatted changelog" do
     expect(parser.parse("spec/fixtures/correct.md")).
+      to be_an_instance_of(Treetop::Runtime::SyntaxNode)
+  end
+
+  it "parses an initial release tag link" do
+    expect(parser.parse("spec/fixtures/correct_initial_tag.md")).
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)
   end
 
@@ -12,7 +17,7 @@ describe ParseAChangelog do
     expect(parser.parse("spec/fixtures/correct_empty_unreleased.md")).
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)
   end
-  
+
   it "parses an empty diff section" do
     expect(parser.parse("spec/fixtures/correct_empty_diff.md")).
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)
@@ -54,13 +59,13 @@ describe ParseAChangelog do
       parser.parse("spec/fixtures/incorrect_release_header_delimiter.md")
     }.to raise_error(ParseAChangelog::ParseError, /line 18/)
   end
-  
+
   it "errors on release header with missing release date" do
     expect {
       parser.parse("spec/fixtures/missing_release_date.md")
     }.to raise_error(ParseAChangelog::ParseError, /line 18/)
   end
-  
+
   it "errors on malformed release date" do
     expect {
       parser.parse("spec/fixtures/malformed_release_date.md")
@@ -72,7 +77,7 @@ describe ParseAChangelog do
       parser.parse("spec/fixtures/malformed_change_header.md")
     }.to raise_error(ParseAChangelog::ParseError, /line 15/)
   end
-  
+
   it "errors on unknown change type" do
     expect {
       parser.parse("spec/fixtures/unknown_change_type.md")
@@ -107,5 +112,11 @@ describe ParseAChangelog do
     expect {
       parser.parse("spec/fixtures/missing_newline_before_diffs.md")
     }.to raise_error(ParseAChangelog::ParseError, /line 29/)
+  end
+
+  it "errors on malformed diff version" do
+    expect {
+      parser.parse("spec/fixtures/malformed_diff_version.md")
+    }.to raise_error(ParseAChangelog::ParseError, /line 10/)
   end
 end


### PR DESCRIPTION
The keepachangelog format accomodates using the tag as a link for the first release, since that captures all the changes from an empty repo to the first release.