### PR TITLE
Pipeline Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Finally, here is an example bash script that runs `parse-a-changelog` on the cur
 ```
 #!/bin/bash -ex
 
-docker run --rm -v "$PWD":/app ruby:2.6 bash -ec "
-  gem install parse_a_changelog
-  parse /app/CHANGELOG.md
+docker run \
+  --rm \
+  --volume "${PWD}/CHANGELOG.md":/CHANGELOG.md"
+  cyberark/parse-a-changelog
 "
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+docker build . --tag parse-a-changelog

--- a/publish.sh
+++ b/publish.sh
@@ -26,4 +26,4 @@ docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:latest"
 docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:${TAG_NAME}"
 
 docker push "${DOCKERHUB_IMAGE}:latest"
-docker push "cyberark/parse-a-changelog:${TAG_NAME}"
+docker push "${DOCKERHUB_IMAGE}:${TAG_NAME}"

--- a/publish.sh
+++ b/publish.sh
@@ -1,10 +1,29 @@
 #!/usr/bin/env bash
 
+# This script will publish to rubygems and dockerhub
+
+if [[ -z "${TAG_NAME:-}" ]]; then
+  echo "Please supply environment variable TAG_NAME."
+  echo "If you see this error in Jenkins it means the publish script was run"
+  echo "for a build that wasn't triggered by a tag - please check publish stage conditions."
+  exit 1
+fi
+
 set -eux
 
+DOCKERHUB_IMAGE="cyberark/parse-a-changelog"
+
+## Publish Gem
 # Image created by https://github.com/conjurinc/publish-rubygem
 docker pull registry.tld/conjurinc/publish-rubygem
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
   docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
   registry.tld/conjurinc/publish-rubygem parse_a_changelog
+
+## Publish to Docker Hub
+docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:latest"
+docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:${TAG_NAME}"
+
+docker push "${DOCKERHUB_IMAGE}:latest"
+docker push "cyberark/parse-a-changelog:${TAG_NAME}"

--- a/validate.sh
+++ b/validate.sh
@@ -2,9 +2,9 @@
 
 set -eux
 
-docker build . -t parse_a_changelog
+# This script validates the changelog in this repo.
 
 docker run \
     --rm \
     -v $PWD/CHANGELOG.md:/CHANGELOG.md \
-    parse_a_changelog
+    cyberark/parse-a-changelog


### PR DESCRIPTION
After committing the initial pipeline based on another gem project,
I decided that the pattern wasn't optimal. Having a 5 minute wait and
requiring human interaction in the build before each verison is
published means that the published version will probably fall behind
the current version.

This commit adds a some logic to determine if the repo version is
the same as the rubygems.org version and publish if not.

Also:
* Push to dockerhub
* Update README
* Separate docker build script out
* Add bash-lib submodule

Related: cyberark/bash-lib#24