### PR TITLE
WIP - Fix end of file error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,23 @@
 PATH
   remote: .
   specs:
-    parse_a_changelog (1.0.1)
+    parse_a_changelog (1.0.2)
       treetop (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
+    coderay (1.1.3)
     diff-lcs (1.3)
+    method_source (1.0.0)
     polyglot (0.3.5)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -24,7 +33,7 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    treetop (1.6.10)
+    treetop (1.6.11)
       polyglot (~> 0.3)
 
 PLATFORMS
@@ -34,6 +43,7 @@ PLATFORMS
 
 DEPENDENCIES
   parse_a_changelog!
+  pry-byebug (~> 3.9.0)
   rspec (~> 3.8)
   rspec_junit_formatter (~> 0.4.1)
 

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -4,20 +4,20 @@ grammar KeepAChangelog
   end
 
   rule changelog_header
-    '# Changelog' "\n"
-    'All notable changes to this project will be documented in this file.' "\n"
-    "\n"
-    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)' "\n"
-    'and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).' "\n"
-    "\n"
+    '# Changelog' new_line
+    'All notable changes to this project will be documented in this file.' new_line
+    new_line
+    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)' new_line
+    'and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).' new_line
+    new_line
   end
 
   rule unreleased_section
-    unreleased_header change_section? ("\n" change_section)*
+    unreleased_header change_section? (new_line change_section)*
   end
 
   rule unreleased_header
-    '## ' '['? 'Unreleased' ']'? "\n"
+    '## ' '['? 'Unreleased' ']'? new_line
   end
 
   rule change_section
@@ -25,11 +25,11 @@ grammar KeepAChangelog
   end
 
   rule change_header
-    '### ' ('Added' / 'Changed' / 'Deprecated' / 'Removed' / 'Fixed' / 'Security') "\n"
+    '### ' ('Added' / 'Changed' / 'Deprecated' / 'Removed' / 'Fixed' / 'Security') new_line
   end
 
   rule change
-    ('- ' / '  ') (!"\n" .)+ "\n"?
+    ('- ' / '  ') (!new_line .)+ new_line?
   end
 
   rule releases_section
@@ -37,11 +37,11 @@ grammar KeepAChangelog
   end
 
   rule release
-    "\n" release_header change_section? ("\n" change_section)*
+    new_line release_header change_section? (new_line change_section)*
   end
 
   rule release_header
-    '## ' '['? release_version ']'? ' - ' release_date "\n"
+    '## ' '['? release_version ']'? ' - ' release_date new_line
   end
 
   rule release_version
@@ -61,19 +61,19 @@ grammar KeepAChangelog
   end
 
   rule diff_section
-    "\n" unreleased_diff release_diff*  initial_release?
+    new_line unreleased_diff release_diff*  initial_release?
   end
 
   rule unreleased_diff
-    '[Unreleased]: ' release_url "\n"
+    '[Unreleased]: ' release_url new_line
   end
 
   rule initial_release
-    '[' release_version ']: ' 'https://github.com/' (!'/' .)+ '/' (!'/' .)+ '/releases/tag/v' release_version "\n"
+    '[' release_version ']: ' 'https://github.com/' (!'/' .)+ '/' (!'/' .)+ '/releases/tag/v' release_version new_line
   end
 
   rule release_diff
-    '[' release_version ']: ' release_url "\n"
+    '[' release_version ']: ' release_url new_line
   end
 
   rule release_url
@@ -82,5 +82,9 @@ grammar KeepAChangelog
 
   rule diff_version
     'HEAD' / ( 'v' release_version )
+  end
+        
+  rule new_line
+    "\n"
   end
 end

--- a/lib/parse_a_changelog.rb
+++ b/lib/parse_a_changelog.rb
@@ -10,9 +10,7 @@ module ParseAChangelog
       parser = KeepAChangelogParser.new
       result = parser.parse(file)
 
-      if !result
-        raise ParseError.new(failure_message(parser))
-      end
+      raise ParseError, failure_message(parser) unless result
 
       result
     end

--- a/lib/parse_a_changelog.rb
+++ b/lib/parse_a_changelog.rb
@@ -10,13 +10,17 @@ module ParseAChangelog
       parser = KeepAChangelogParser.new
       result = parser.parse(file)
 
-      raise ParseError, failure_message(parser) unless result
-
+      unless result
+        raise parser_error(
+                parser.failure_line, parser.failure_column, parser.failure_reason
+              )
+      end
+      
       result
     end
 
-    def failure_message(parser)
-      parser.failure_reason.split(' after ')[0]
+    def parser_error(line, column, reason)
+      ParseError.new("line #{line}, column #{column}: #{reason}")
     end
   end
 end

--- a/parse_a_changelog.gemspec
+++ b/parse_a_changelog.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'treetop', '~> 1.6'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
+  s.add_development_dependency 'pry-byebug', '~> 3.9.0'
 end

--- a/spec/fixtures/missing_newline_at_eof.md
+++ b/spec/fixtures/missing_newline_at_eof.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added a thing.
+
+### Changed
+- Changed a thing.
+
+## [1.0.0] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## 0.1.0 - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+### Fixed
+- Fixed all the bugs from the non-existent previous release.
+
+### Security
+- We are so secure now.
+- The securest.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -103,7 +103,7 @@ describe ParseAChangelog do
   it "errors on missing newline at end of file" do
     expect {
       parser.parse("spec/fixtures/missing_newline_at_eof.md")
-    }.to raise_error(ParseAChangelog::ParseError, /line 30/)
+    }.to raise_error(ParseAChangelog::ParseError, /line 31/)
   end
 
   it "errors on missing newline before unreleased section" do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -100,6 +100,12 @@ describe ParseAChangelog do
     }.to raise_error(ParseAChangelog::ParseError, /line 12/)
   end
 
+  it "errors on missing newline at end of file" do
+    expect {
+      parser.parse("spec/fixtures/missing_newline_at_eof.md")
+    }.to raise_error(ParseAChangelog::ParseError, /line 30/)
+  end
+
   it "errors on missing newline before unreleased section" do
     expect {
       parser.parse("spec/fixtures/missing_newline_before_unreleased.md")


### PR DESCRIPTION
In case the CHANGELOG file doesn't have a newline at its end, we get the error `NoMethodError: undefined method `split' for nil:NilClass` instead of something useful. 

We should fix this so that we raise a proper error.