### PR TITLE
Make SemVer optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Allow CHANGELOG without SemVer declaration.
+  [cyberark/parse-a-changelog#37](https://github.com/cyberark/parse-a-changelog/issues/37)
+
 ## [1.1.0] - 2020-11-12
 ### Added
 - Allow for metadata section in version string.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_a_changelog (1.0.2)
+    parse_a_changelog (1.1.0)
       treetop (~> 1.6)
 
 GEM
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.20

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -7,8 +7,8 @@ grammar KeepAChangelog
     '# Changelog' new_line
     'All notable changes to this project will be documented in this file.' new_line
     new_line
-    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)' new_line
-    'and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).' new_line
+    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)' '.'? new_line
+    ('and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).' new_line)?
     new_line
   end
 

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -8,7 +8,7 @@ grammar KeepAChangelog
     'All notable changes to this project will be documented in this file.' new_line
     new_line
     keep_a_changelog_format '.'? new_line
-    (semver new_line)?
+    (semver_convention new_line)?
     new_line
   end
 
@@ -16,7 +16,7 @@ grammar KeepAChangelog
     'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)'
   end
 
-  rule semver
+  rule semver_convention
     'and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).'
   end
 

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -7,9 +7,17 @@ grammar KeepAChangelog
     '# Changelog' new_line
     'All notable changes to this project will be documented in this file.' new_line
     new_line
-    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)' '.'? new_line
-    ('and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).' new_line)?
+    keep_a_changelog_format '.'? new_line
+    (semver new_line)?
     new_line
+  end
+
+  rule keep_a_changelog_format
+    'The format is based on [Keep a Changelog](http' 's'? '://keepachangelog.com/en/1.0.0/)'
+  end
+
+  rule semver
+    'and this project adheres to [Semantic Versioning](http' 's'? '://semver.org/spec/v2.0.0.html).'
   end
 
   rule unreleased_section

--- a/spec/fixtures/correct_no_semver.md
+++ b/spec/fixtures/correct_no_semver.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+### Added
+- Added a thing.
+
+### Changed
+- Changed a thing.
+
+## [1.0.0] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## 0.1.0 - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+### Fixed
+- Fixed all the bugs from the non-existent previous release.
+
+### Security
+- We are so secure now.
+- The securest.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -43,6 +43,11 @@ describe ParseAChangelog do
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)
   end
 
+  it "parses a changelog without a SemVer declaration" do
+    expect(parser.parse("spec/fixtures/correct_no_semver.md")).
+      to be_an_instance_of(Treetop::Runtime::SyntaxNode)
+  end
+
   it "errors on malformed changelog header" do
     expect {
       parser.parse("spec/fixtures/malformed_changelog_header.md")


### PR DESCRIPTION
### What does this PR do?
The Conjur on RHEL project does not adhere to Semantic
Versioning so we need to let its CHANGELOG to not have the
line declaring on it.

### What ticket does this PR close?
Resolves #37 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes

#### Documentation
- [x] This PR does not require updating any documentation