### PR TITLE
Allow fourth level of version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.0] - 2023-07-12
+### Changed
+- Allow versions to have 4 digits (eg., x.x.x.x)
+  [cyberark/parse-a-changelog#41](https://github.com/cyberark/parse-a-changelog/pulls/41)
+
 ## [1.2.0] - 2021-06-20
 ### Changed
 - Allow CHANGELOG without SemVer declaration.
@@ -77,7 +82,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Open source license and contributing information
 - Change log and versioning information
 
-[Unreleased]: https://github.com/cyberark/parse-a-changelog/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/cyberark/parse-a-changelog/compare/v1.3.0...HEAD
+[1.2.0]: https://github.com/cyberark/parse-a-changelog/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/cyberark/parse-a-changelog/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/cyberark/parse-a-changelog/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/cyberark/parse-a-changelog/compare/v1.0.1...v1.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_a_changelog (1.1.0)
+    parse_a_changelog (1.2.0)
       treetop (~> 1.6)
 
 GEM
@@ -33,7 +33,7 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    treetop (1.6.11)
+    treetop (1.6.12)
       polyglot (~> 0.3)
 
 PLATFORMS
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
 
 BUNDLED WITH
-   2.2.20
+   2.2.33

--- a/lib/grammar.tt
+++ b/lib/grammar.tt
@@ -53,7 +53,7 @@ grammar KeepAChangelog
   end
 
   rule release_version
-    [0-9]+ '.' [0-9]+ '.' [0-9]+ pre_release_version metadata
+    [0-9]+ '.' [0-9]+ '.' [0-9]+ fourth_version_digit pre_release_version metadata
   end
 
   rule pre_release_version
@@ -64,6 +64,10 @@ grammar KeepAChangelog
     ( '+' [0-9A-Za-z-]+ dot_separated_group*  ) / ''
   end
 
+  rule fourth_version_digit
+    ( '.' [0-9]+) / ''
+  end
+  
   rule dot_separated_group
     '.' [0-9A-Za-z-]+
   end

--- a/spec/fixtures/correct_with_4_digit_version.md
+++ b/spec/fixtures/correct_with_4_digit_version.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [1.0.0.1] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## 0.1.0 - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v1.0.0+metadata.1-rc123...HEAD
+[1.0.0+metadata.1]: https://github.com/conjurinc/evoke/compare/v1.0.0...v1.0.0+metadata.1
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0

--- a/spec/fixtures/correct_with_4_digit_version_and_metadata.md
+++ b/spec/fixtures/correct_with_4_digit_version_and_metadata.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [1.0.0.1+metadata.1] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## 0.1.0 - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v1.0.0+metadata.1-rc123...HEAD
+[1.0.0+metadata.1]: https://github.com/conjurinc/evoke/compare/v1.0.0...v1.0.0+metadata.1
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0

--- a/spec/fixtures/correct_with_4_digit_version_and_pre_release.md
+++ b/spec/fixtures/correct_with_4_digit_version_and_pre_release.md
@@ -1,0 +1,52 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+- Fixed a thing
+
+## [2.0.0.1-rc123] - 2020-08-26
+### Added
+- Added a thing.
+
+## [1.0.0.1-alpha] - 2020-08-25
+### Added
+- Added a thing.
+
+## [1.0.0.1-alpha.1] - 2020-08-24
+### Added
+- Added a thing.
+
+## [1.0.0.1-0.3.7] - 2020-08-23
+### Added
+- Added a thing.
+
+## [1.0.0-x.7.z.92] - 2020-08-22
+### Added
+- Added a thing.
+
+## [1.0.0-x-y-z.-] - 2020-08-21
+### Added
+- Added a thing.
+
+## [1.0.0] - 2019-01-03
+### Deprecated
+- Some things were deprecated.
+
+## 0.1.0 - 2018-11-28
+### Removed
+- Removed all
+  the things.
+
+[Unreleased]: https://github.com/conjurinc/evoke/compare/v2.0.0-rc123...HEAD
+[2.0.0-rc123]: https://github.com/conjurinc/evoke/compare/v1.0.0-alpha...v2.0.0-rc123
+[1.0.0-alpha]: https://github.com/conjurinc/evoke/compare/v1.0.0-alpha.1...v1.0.0-alpha
+[1.0.0-alpha.1]: https://github.com/conjurinc/evoke/compare/v1.0.0-0.3.7...v1.0.0-alpha.1
+[1.0.0-0.3.7]: https://github.com/conjurinc/evoke/compare/v1.0.0-x.7.z.92...v1.0.0-0.3.7
+[1.0.0-x.7.z.92]: https://github.com/conjurinc/evoke/compare/v1.0.0-x-y-z.-...v1.0.0-x.7.z.92
+[1.0.0-x-y-z.-]: https://github.com/conjurinc/evoke/compare/v1.0.0...v1.0.0-x-y-z.-
+[1.0.0]: https://github.com/conjurinc/evoke/compare/v0.1.0...v1.0.0

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -8,6 +8,21 @@ describe ParseAChangelog do
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)
   end
 
+  it "parses a 4 digit version" do
+    expect(parser.parse("spec/fixtures/correct_with_4_digit_version.md")).
+      to be_an_instance_of(Treetop::Runtime::SyntaxNode)
+  end
+
+  it "parses a 4 digit version with version metadata" do
+    expect(parser.parse("spec/fixtures/correct_with_4_digit_version_and_metadata.md")).
+      to be_an_instance_of(Treetop::Runtime::SyntaxNode)
+  end
+  
+  it "parses a 4 digit version with a release candidate version" do
+    expect(parser.parse("spec/fixtures/correct_with_4_digit_version_and_pre_release.md")).
+      to be_an_instance_of(Treetop::Runtime::SyntaxNode)
+  end
+  
   it "parses an initial release tag link" do
     expect(parser.parse("spec/fixtures/correct_initial_tag.md")).
       to be_an_instance_of(Treetop::Runtime::SyntaxNode)


### PR DESCRIPTION
### Desired Outcome

When we have to go back and cut updates to previously released versions, we need to be able to add a fourth number to the version so as to not interrupt current dev work. Make parse-a-changelog accept those 4 number versions.

### Implemented Changes

Added a rule that optionally allows an X.X.X.X version number (with or without version metadata and pre-release info)