### PR TITLE
Fix gem name in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This gem can be used to validate that a file conforms to the [Keep a Changelog](
 
 ## Usage
 
-Add `parse-a-changelog` to your `Gemfile` and `bundle install` or install it directly with:
+Add `parse_a_changelog` to your `Gemfile` and `bundle install` or install it directly with:
 
 ```
-gem install parse-a-changelog
+gem install parse_a_changelog
 ```
 
 The gem includes a binary that can be run with the changelog file as its single argument:


### PR DESCRIPTION
`parse_a_changelog` instead of `parse-a-changelog`

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
