### PR TITLE
CONJSE-1802: Migrate Publish rubygems to release-tools/publish-rubygems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  task :spec
+end
+
+task default: :spec

--- a/parse_a_changelog.gemspec
+++ b/parse_a_changelog.gemspec
@@ -1,21 +1,25 @@
-Gem::Specification.new do |s|
-  s.name = %q{parse_a_changelog}
-  s.version = `cat < VERSION`
-  s.authors = ["John Tuttle"]
-  s.email = "jtuttle.develops@gmail.com"
+Gem::Specification.new do |spec|
+  spec.name = "parse_a_changelog"
+  spec.version = `cat < VERSION`
+  spec.authors = ["John Tuttle"]
+  spec.email = "jtuttle.develops@gmail.com"
   
-  s.summary = %q{A validator for the keep-a-changelog format}
-  s.description = %q{Uses a grammar describing the keep-a-changelog format to attempt to parse a given file.}
-  s.homepage = "http://github.com/cyberark/parse-a-changelog"
-  s.license = "Apache-2.0"
+  spec.summary = %q{A validator for the keep-a-changelog format}
+  spec.description = %q{Uses a grammar describing the keep-a-changelog format to attempt to parse a given file.}
+  spec.homepage = "http://github.com/cyberark/parse-a-changelog"
+  spec.license = "Apache-2.0"
   
-  s.files = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md CHANGELOG.md VERSION)
-  s.bindir = 'bin'
-  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  #spec.files = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md CHANGELOG.md VERSION)
+  spec.files         = `git ls-files`.split($\)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  #spec.files = `git ls-files`.split($\) + %w(LICENSE README.md CHANGELOG.md VERSION)
+  spec.bindir = 'bin'
+  #spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
-  s.add_dependency 'treetop', '~> 1.6'
-  s.add_development_dependency 'rspec', '~> 3.8'
-  s.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
-  s.add_development_dependency 'pry-byebug', '~> 3.9.0'
+  spec.add_dependency 'treetop', '~> 1.6'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.6'
+  spec.add_development_dependency 'pry-byebug', '~> 3.10'
 end

--- a/publish.sh
+++ b/publish.sh
@@ -1,27 +1,18 @@
 #!/usr/bin/env bash
 
+set -e
+
 # This script will publish to rubygems and dockerhub
 
-if [[ -z "${TAG_NAME:-}" ]]; then
-  echo "Please supply environment variable TAG_NAME."
-  echo "If you see this error in Jenkins it means the publish script was run"
-  echo "for a build that wasn't triggered by a tag - please check publish stage conditions."
-  exit 1
-fi
+git clone git@github.com:conjurinc/release-tools.git
 
-set -eux
+export PATH=$PWD/release-tools/bin/:$PATH
 
-DOCKERHUB_IMAGE="cyberark/parse-a-changelog"
-
-## Publish Gem
-# Image created by https://github.com/conjurinc/publish-rubygem
-docker pull registry.tld/conjurinc/publish-rubygem
-
+# Build and publish rubygem
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/publish-rubygem parse_a_changelog
+  publish-rubygem parse_a_changelog
 
-## Publish to Docker Hub
+# Publish to Docker Hub
 docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:latest"
 docker tag parse-a-changelog "${DOCKERHUB_IMAGE}:${TAG_NAME}"
 

--- a/test.sh
+++ b/test.sh
@@ -2,11 +2,16 @@
 
 set -eux
 
-docker run \
-    -v $PWD:/work \
-    -w /work \
-    ruby:3 \
-        bash -c "git config --global --add safe.directory /work; \
-                 gem install bundler --no-document; \
-                 bundle install; \
-                 bundle exec rspec"
+echo "==> Starting test.sh"
+
+echo "==> Docker Run"
+
+docker run --rm \
+    --volume $PWD:/work \
+    --workdir /work \
+    cyberark/ubuntu-ruby-builder \
+      bash -c 'git config --global \
+      --add safe.directory /work && \
+      bundle install && bundle exec rspec' 
+
+echo "==> End of test.sh"


### PR DESCRIPTION

Remove remaining dependencies on conjurinc/publish_rubygem container

    https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1802

Migrated from github.com to GitHub Enterprise.
Changes made for CVE-2023-5129

    Updated to use Ruby ~> 3.0
    Updated to use conjur-enterprise/release-tools/publish-rubygem

