### PR TITLE
Update Dockerfile to use latest Ruby v3 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.3.0] - 2023-07-12
+## [1.3.0] - 2023-12-28
 ### Changed
 - Allow versions to have 4 digits (eg., x.x.x.x)
   [cyberark/parse-a-changelog#41](https://github.com/cyberark/parse-a-changelog/pulls/41)
+
+### Security
+- Updated Dockerfile base image to use latest Ruby v3 version
+  [cyberark/parse-a-changelog#46](https://github.com/cyberark/parse-a-changelog/pulls/46)
 
 ## [1.2.0] - 2021-06-20
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ruby:3
 
 RUN gem install bundler --no-document
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_a_changelog (1.2.0)
+    parse_a_changelog (1.3.0)
       treetop (~> 1.6)
 
 GEM
@@ -9,7 +9,7 @@ GEM
   specs:
     byebug (11.1.3)
     coderay (1.1.3)
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     method_source (1.0.0)
     polyglot (0.3.5)
     pry (0.13.1)
@@ -18,19 +18,19 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     treetop (1.6.12)
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
 
 BUNDLED WITH
-   2.2.33
+   2.4.14

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -4,7 +4,7 @@ The following libraries licensed under the MIT license are used
 within this repository:
 
 * rspec - https://rubygems.org/gems/rspec 
-* treetop - https://rubygems.org/gems/treetop/versions/1.6.5
+* treetop - https://rubygems.org/gems/treetop/versions/1.6.12
 
 MIT License - https://opensource.org/licenses/MIT
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -eux
 docker run \
     -v $PWD:/work \
     -w /work \
-    ruby:3.1 \
+    ruby:3 \
         bash -c "git config --global --add safe.directory /work; \
                  gem install bundler --no-document; \
                  bundle install; \


### PR DESCRIPTION
### Desired Outcome

Snyk is flagging vulnerabilities in the Ruby v3.1 image. There's no reason not to unpin the minor version here and just use the latest 3.x version.

### Implemented Changes

- Changed the base image from ruby:3.1 to ruby:3
- Ran `bundle update` to get the latest versions of gem dependencies

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
